### PR TITLE
remove: entrypoint.sh now is a direct command in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Log ontology if DEBUG is enabled
 
+### Removed
+- entrypoint.sh now is a direct command in Dockerfile
+- buildDockerImage.sh Instead use `sudo docker build -t dataspace-connector-ui .`
+
 
 ## [10.0.1] - 2022-08-19
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN rm -r .git
 RUN sed -i "s@http://localhost:8083@@g" dist/js/*.js
 RUN groupadd -r nonroot && useradd -r -g nonroot nonroot
 USER nonroot
-ENTRYPOINT ["./entryPoint.sh"]
+CMD ["npm", "run", "backend"]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This can process POST and GET requests.
 
 Build docker image:
 ```bash
-./buildDockerImage.sh
+sudo docker build -t dataspace-connector-ui .
 ```
 Run docker image:
 ```bash

--- a/buildDockerImage.sh
+++ b/buildDockerImage.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-sudo docker build -t dataspace-connector-ui .

--- a/entryPoint.sh
+++ b/entryPoint.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-npm run backend


### PR DESCRIPTION
remove: buildDockerImage.sh Instead use `sudo docker build -t dataspace-connector-ui .`